### PR TITLE
Chart: add pdb parameter

### DIFF
--- a/chart/k8s-pause/Chart.yaml
+++ b/chart/k8s-pause/Chart.yaml
@@ -14,4 +14,4 @@ keywords:
 name: k8s-pause
 sources:
 - https://github.com/DoodleScheduling/k8s-pause
-version: 0.2.7
+version: 0.2.8

--- a/chart/k8s-pause/templates/pdb.yaml
+++ b/chart/k8s-pause/templates/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "k8s-pause.fullname" . }}-pdb
+  labels:
+    app.kubernetes.io/name: {{ include "k8s-pause.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "k8s-pause.chart" . }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end  }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "k8s-pause.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/k8s-pause/values.yaml
+++ b/chart/k8s-pause/values.yaml
@@ -91,6 +91,12 @@ envFromSecret: ""
 ##     key: password
 extraEnvSecrets: {}
 
+# Ability to set a PodDisruptionBudget
+pdb:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
## Current situation

I am unable to create a PodDisruptionBudget (PDB), and when the k8s-pause service is down, the mutatingwebhookconfiguration fails. This failure prevents my cluster from creating new pods.

## Proposal

Being able to have a PodDisruptionBudget (PDB) should help me with this issue.
