### PR TITLE
Add never suspend annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Resume:
 kubectl annotate ns/my-namespace k8s-pause/suspend=false --overwrite
 ```
 
+## `k8s-pause/ignore` annotation
+
+You can define an annotation on a pod to ensure it is ignored by the controller
+and so never suspended. Use the following annotation:
+
+```
+k8s-pause/ignore: "true"
+```
+
 ## Resume profiles
 
 It is possible to define a set of pods which are allowed to start while a namespace is not paused.

--- a/controllers/namespace_controller.go
+++ b/controllers/namespace_controller.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	previousSchedulerName = "k8s-pause/previousScheduler"
+	ignoreAnnotation      = "k8s-pause/ignore"
 )
 
 // NamespaceReconciler reconciles a Namespace object
@@ -145,6 +146,10 @@ func (r *NamespaceReconciler) resume(ctx context.Context, ns corev1.Namespace, p
 	}
 
 	for _, pod := range list.Items {
+		if ignore, ok := pod.Annotations[ignoreAnnotation]; ok && ignore == "true" {
+			continue
+		}
+
 		if profile != nil {
 			if !matchesResumeProfile(pod, *profile) {
 				continue
@@ -226,6 +231,10 @@ func (r *NamespaceReconciler) suspend(ctx context.Context, ns corev1.Namespace, 
 	}
 
 	for _, pod := range list.Items {
+		if ignore, ok := pod.Annotations[ignoreAnnotation]; ok && ignore == "true" {
+			continue
+		}
+
 		if err := r.suspendPod(ctx, pod, logger); err != nil {
 			logger.Error(err, "failed to suspend pod", "pod", pod.Name)
 			continue


### PR DESCRIPTION
## Current Situation
Currently, there is no simple way to exclude specific pods from being suspended.

## Proposal
Introduce a concise annotation to easily identify and exclude pods that should not be suspended.