### PR TITLE
Dockerfile: Enable multi-platform image support with in-docker Go com…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
+FROM golang:1.21 as builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN make build
+
 FROM gcr.io/distroless/static:nonroot
+
 WORKDIR /
-COPY manager manager
+COPY --from=builder /app/manager /manager
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Multi-platform image

```
docker build --platform linux/amd64,linux/arm64 -t x/k8s-pause:TAG
```